### PR TITLE
Added custom_state attribute as ACTIVATE replacement

### DIFF
--- a/src/state-summary/state-card-script.html
+++ b/src/state-summary/state-card-script.html
@@ -30,7 +30,7 @@
         <ha-entity-toggle state-obj='[[stateObj]]' hass='[[hass]]'></ha-entity-toggle>
       </template>
       <template is='dom-if' if='[[!stateObj.attributes.can_cancel]]'>
-        <paper-button on-click='fireScript'>ACTIVATE</paper-button>
+        <paper-button on-click='fireScript'>[[_getText()]]</paper-button>
       </template>
     </div>
   </template>
@@ -57,6 +57,14 @@ class StateCardScript extends Polymer.Element {
       'script', 'turn_on',
       { entity_id: this.stateObj.entity_id }
     );
+  }
+  
+  _getText() {
+    if(this.stateObj.attributes.custom_text) {
+      return this.stateObj.attributes.custom_text;
+    } else {
+      return 'ACTIVATE';
+    }
   }
 }
 customElements.define(StateCardScript.is, StateCardScript);


### PR DESCRIPTION
Added 'custom_state' state attribute as "ACTIVATE" replacement if exists.
If not, the standard "ACTIVATE" will be used.

Example for the yaml configuration:
```yaml
#customize.yaml
script.icloud_find_hava_iphone:
  friendly_name: "Find Hava's iPhone"
  icon: mdi:magnify
  custom_text: "FIND"
script.icloud_find_tomer_iphone:
  friendly_name: "Find Tomer's iPhone"
  icon: mdi:magnify
  custom_text: "FIND"
script.get_sensors_report_notificiation_from_ui:
  friendly_name: "Get Sensors Report"
  icon: mdi:file-chart
  custom_text: "GET"
```
Frontend Result:
![frontend-example](https://user-images.githubusercontent.com/28388442/39074060-a8472ba4-44f8-11e8-895d-fd183b0f7279.jpg)

I've tested it on my production environment as a custom-ui-state-card and not as a whole in my development environment, which I'm trying to build these days.
If it's a problem I'll be happy to report back my full testing results once I'll get my environment up and running. 
It's a pretty small change, I think my testing it as a custom-ui-state-card should be enough.

I've shared my custom-state-card [here](https://github.com/TomerFi/home-assistant-custom-ui#script-with-custom-text).
I'm also working on updating the `script` component in `home-assistant` so that the configuration schema will allow setting the `custom_text` attribute as part of the `script` configuration, I already have it working in my development environment.
If this pull request will be approved, I'll create one for `home-assistant` as well.